### PR TITLE
Track, Identify and Screen methods have been modified to accept a SEG…

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -9,4 +9,5 @@ target 'Segment-Kahuna_Tests', :exclusive => true do
 
   pod 'Specta'
   pod 'Expecta'
+  pod 'OCMockito'
 end

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -1,30 +1,283 @@
 //
-//  Segment-KahunaTests.m
-//  Segment-KahunaTests
+//  SEGKahunaIntegrationTests.m
+//  Analytics
 //
-//  Created by Prateek Srivastava on 11/23/2015.
-//  Copyright (c) 2015 Prateek Srivastava. All rights reserved.
+//  Copyright (c) 2015 Segment.io. All rights reserved.
 //
 
-// https://github.com/Specta/Specta
+#import <XCTest/XCTest.h>
+#import "SEGKahunaDefines.h"
+#import "SEGKahunaIntegration.h"
+#import <Kahuna/Kahuna.h>
 
-SpecBegin(InitialSpecs);
+#define HC_SHORTHAND
+#import <OCHamcrest/OCHamcrest.h>
 
-describe(@"these will pass", ^{
-    
-    it(@"can do maths", ^{
-        expect(1).beLessThan(23);
-    });
-    
-    it(@"can read", ^{
-        expect(@"team").toNot.contain(@"I");
-    });
-    
-    it(@"will wait and succeed", ^{
-        waitUntil(^(DoneCallback done) {
-            done();
-        });
-    });
-});
+#define MOCKITO_SHORTHAND
+#import <OCMockito/OCMockito.h>
 
-SpecEnd
+
+@interface SEGKahunaIntegrationTests : XCTestCase
+
+@property SEGKahunaIntegration *integration;
+@property Class kahunaClassMock;
+@property Class nserrorClassMock;
+@property NSError *nserrorMock;
+@property Kahuna *kahunaMock;
+@property KahunaUserCredentials *kahunaCredentialsMock;
+
+@end
+
+
+@implementation SEGKahunaIntegrationTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    _kahunaMock = mock([Kahuna class]);
+    _kahunaClassMock = mockClass([Kahuna class]);
+    _nserrorMock = mock([NSError class]);
+    _nserrorClassMock = mockClass([NSError class]);
+    _kahunaCredentialsMock = mock([KahunaUserCredentials class]);
+    
+    [given([_kahunaClassMock sharedInstance]) willReturn:_kahunaMock];
+    [given([_kahunaClassMock createUserCredentials]) willReturn:_kahunaCredentialsMock];
+    [given([_nserrorClassMock errorWithDomain:anything() code:anything() userInfo:anything()]) willReturn:_nserrorMock];
+    
+    _integration = [[SEGKahunaIntegration alloc] init];
+    [_integration setKahunaClass:_kahunaClassMock];
+}
+
+- (void)testStart
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    
+    [verifyCount(_kahunaClassMock, times(1)) launchWithKey:@"foo"];
+}
+
+- (void)testReset
+{
+    [_integration reset];
+    
+    [verifyCount(_kahunaClassMock, times(1)) logout];
+}
+
+- (void)testIdentify
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
+                                   initWithUserId:@"foo"
+                                   anonymousId:nil
+                                   traits:@{ @"bar" : @"baz" } context:nil integrations:nil];
+    [_integration identify:payload];
+    
+    // Verify that Add Credential was called once on the KahunaCredentialsMock object.
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_USER_ID withValue:@"foo"];
+    
+    [[verifyCount(_kahunaClassMock, times(1)) withMatcher:anything() forArgument:1] loginWithCredentials:_kahunaCredentialsMock error:nil];
+    [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{ @"bar" : @"baz" }];
+}
+
+- (void)testIdentifyWithNoTraits
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
+                                   initWithUserId:@"foo"
+                                   anonymousId:nil
+                                   traits:@{} context:nil integrations:nil];
+    
+    [_integration identify:payload];
+    
+    // Verify that Add Credential was called once on the KahunaCredentialsMock object.
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_USER_ID withValue:@"foo"];
+    
+    [[verifyCount(_kahunaClassMock, times(1)) withMatcher:anything() forArgument:1] loginWithCredentials:_kahunaCredentialsMock error:nil];
+    [verifyCount(_kahunaClassMock, never()) setUserAttributes:anything()];
+}
+
+- (void)testIdentifyWithNoCredentialsAndNoTraits
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
+                                   initWithUserId:nil
+                                   anonymousId:nil
+                                   traits:@{} context:nil integrations:nil];
+    
+    [_integration identify:payload];
+    
+    // Verify that Add Credential was called once on the KahunaCredentialsMock object.
+    [verifyCount(_kahunaCredentialsMock, never()) addCredential:anything() withValue:anything()];
+    
+    [[verifyCount(_kahunaClassMock, times(1)) withMatcher:anything() forArgument:1] loginWithCredentials:_kahunaCredentialsMock error:nil];
+    [verifyCount(_kahunaClassMock, never()) setUserAttributes:anything()];
+}
+
+- (void)testIdentifyWithMultipleCredentialsAndTraits
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
+                                   initWithUserId:@"foo"
+                                   anonymousId:nil
+                                   traits:@{ @"bar" : @"baz",
+                                             KAHUNA_CREDENTIAL_EMAIL : @"segkah@gmail.com",
+                                             @"moon" : @"drake" } context:nil integrations:nil];
+    
+    [_integration identify:payload];
+    
+    // Verify that Add Credential was called twice on the KahunaCredentialsMock object.
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_USER_ID withValue:@"foo"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_EMAIL withValue:@"segkah@gmail.com"];
+    
+    [[verifyCount(_kahunaClassMock, times(1)) withMatcher:anything() forArgument:1] loginWithCredentials:_kahunaCredentialsMock error:nil];
+    [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{ @"bar" : @"baz", @"moon" : @"drake" }];
+}
+
+- (void)testTrack
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
+                                                           properties:@{}
+                                                              context:nil
+                                                         integrations:nil];
+    
+    [_integration track:payload];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+}
+
+- (void)testTrackWithRevenueButNoQuantity
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
+                                                           properties:@{ @"revenue" : @10 }
+                                                              context:nil
+                                                         integrations:nil];
+    
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+    [verifyCount(_kahunaClassMock, never()) trackEvent:@"foo" withCount:anything() andValue:anything()];
+}
+
+- (void)testTrackWithQuantityButNoRevenue
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
+                                                           properties:@{ @"quantity" : @10 }
+                                                              context:nil
+                                                         integrations:nil];
+    
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+    [verifyCount(_kahunaClassMock, never()) trackEvent:@"foo" withCount:anything() andValue:anything()];
+}
+
+- (void)testTrackWithQuantityAndRevenue
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
+                                                           properties:@{ @"revenue" : @10, @"quantity" : @4 }
+                                                              context:nil
+                                                         integrations:nil];
+    
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, never()) trackEvent:anything()];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo" withCount:4 andValue:1000];
+}
+
+- (void)testTrackWithQuantityRevenueAndProperties
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
+                                                           properties:@{@"productId" : @"bar",
+                                                                        @"quantity" : @10,
+                                                                        @"receipt" : @"baz",
+                                                                        @"revenue" : @5
+                                                                        }
+                                                              context:nil
+                                                         integrations:nil];
+    
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo" withCount:10 andValue:500];
+}
+
+- (void)testTrackWithPropertyViewedCategory
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_VIEWED_PRODUCT_CATEGORY
+                                                           properties:@{ KAHUNA_CATEGORY : @"shirts" }
+                                                              context:nil
+                                                         integrations:nil];
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_VIEWED_CATEGORY : @"shirts", KAHUNA_CATEGORIES_VIEWED : @"shirts" }];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_VIEWED_PRODUCT_CATEGORY];
+}
+
+- (void)testTrackWithPropertyViewedProduct
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_VIEWED_PRODUCT
+                                                           properties:@{ KAHUNA_NAME : @"gopher shirts" }
+                                                              context:nil
+                                                         integrations:nil];
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_PRODUCT_VIEWED_NAME : @"gopher shirts",
+                                                                 KAHUNA_CATEGORIES_VIEWED : KAHUNA_NONE,
+                                                                 KAHUNA_LAST_VIEWED_CATEGORY : KAHUNA_NONE }];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_VIEWED_PRODUCT];
+    
+}
+
+- (void)testTrackWithPropertyAddedProduct
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_ADDED_PRODUCT
+                                                           properties:@{ KAHUNA_NAME : @"gopher shirts" }
+                                                              context:nil
+                                                         integrations:nil];
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_PRODUCT_ADDED_TO_CART_NAME : @"gopher shirts",
+                                                                 KAHUNA_LAST_PRODUCT_ADDED_TO_CART_CATEGORY : KAHUNA_NONE }];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_ADDED_PRODUCT];
+}
+
+- (void)testTrackWithPropertyCompletedOrder
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_COMPLETED_ORDER
+                                                           properties:@{ KAHUNA_DISCOUNT : @15.0 }
+                                                              context:nil
+                                                         integrations:nil];
+    [_integration track:payload];
+    
+    [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_PURCHASE_DISCOUNT : @15.0 }];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_COMPLETED_ORDER];
+}
+
+- (void)testScreen
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo", @"trackAllPages" : @1 }];
+    
+    SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"foo" properties:@{} context:nil integrations:nil];
+    
+    [_integration screen:payload];
+    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"Viewed foo Screen"];
+}
+
+- (void)testScreenWithNoTrackAllPagesSettings
+{
+    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"foo" properties:@{} context:nil integrations:nil];
+    
+    [_integration screen:payload];
+    
+    [verifyCount(_kahunaClassMock, never()) trackEvent:anything()];
+}
+
+@end

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -1,8 +1,7 @@
 //
 //  SEGKahunaIntegrationTests.m
-//  Analytics
 //
-//  Copyright (c) 2015 Segment.io. All rights reserved.
+//  Copyright (c) 2012-2016 Kahuna. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -15,6 +15,7 @@
 #define MOCKITO_SHORTHAND
 #import <OCMockito/OCMockito.h>
 
+#define INIT_WITH_SETTINGS [_integration initWithSettings:@{ @"apiKey" : @"foo" }]
 
 @interface SEGKahunaIntegrationTests : XCTestCase
 
@@ -50,8 +51,7 @@
 
 - (void)testStart
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
-    
+    INIT_WITH_SETTINGS;
     [verifyCount(_kahunaClassMock, times(1)) launchWithKey:@"foo"];
 }
 
@@ -64,7 +64,7 @@
 
 - (void)testIdentify
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
                                    initWithUserId:@"foo"
                                    anonymousId:nil
@@ -80,7 +80,7 @@
 
 - (void)testIdentifyWithNoTraits
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
                                    initWithUserId:@"foo"
                                    anonymousId:nil
@@ -97,7 +97,7 @@
 
 - (void)testIdentifyWithNoCredentialsAndNoTraits
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
                                    initWithUserId:nil
                                    anonymousId:nil
@@ -114,19 +114,33 @@
 
 - (void)testIdentifyWithMultipleCredentialsAndTraits
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc]
                                    initWithUserId:@"foo"
                                    anonymousId:nil
                                    traits:@{ @"bar" : @"baz",
                                              KAHUNA_CREDENTIAL_EMAIL : @"segkah@gmail.com",
+                                             KAHUNA_CREDENTIAL_FACEBOOK : @"fb",
+                                             KAHUNA_CREDENTIAL_TWITTER : @"tw",
+                                             KAHUNA_CREDENTIAL_LINKEDIN : @"lnk",
+                                             KAHUNA_CREDENTIAL_USER_ID : @"uid",
+                                             KAHUNA_CREDENTIAL_GOOGLE_PLUS : @"gp",
+                                             KAHUNA_CREDENTIAL_INSTALL_TOKEN : @"it",
+                                             KAHUNA_CREDENTIAL_USERNAME : @"un",
                                              @"moon" : @"drake" } context:nil integrations:nil];
     
     [_integration identify:payload];
     
     // Verify that Add Credential was called twice on the KahunaCredentialsMock object.
     [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_USER_ID withValue:@"foo"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_USER_ID withValue:@"uid"];
     [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_EMAIL withValue:@"segkah@gmail.com"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_FACEBOOK withValue:@"fb"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_TWITTER withValue:@"tw"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_LINKEDIN withValue:@"lnk"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_GOOGLE_PLUS withValue:@"gp"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_INSTALL_TOKEN withValue:@"it"];
+    [verifyCount(_kahunaCredentialsMock, times(1)) addCredential:KAHUNA_CREDENTIAL_USERNAME withValue:@"un"];
     
     [[verifyCount(_kahunaClassMock, times(1)) withMatcher:anything() forArgument:1] loginWithCredentials:_kahunaCredentialsMock error:nil];
     [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{ @"bar" : @"baz", @"moon" : @"drake" }];
@@ -134,7 +148,7 @@
 
 - (void)testTrack
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
                                                            properties:@{}
                                                               context:nil
@@ -146,7 +160,7 @@
 
 - (void)testTrackWithRevenueButNoQuantity
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
                                                            properties:@{ @"revenue" : @10 }
                                                               context:nil
@@ -160,7 +174,7 @@
 
 - (void)testTrackWithQuantityButNoRevenue
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
                                                            properties:@{ @"quantity" : @10 }
                                                               context:nil
@@ -174,7 +188,7 @@
 
 - (void)testTrackWithQuantityAndRevenue
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
                                                            properties:@{ @"revenue" : @10, @"quantity" : @4 }
                                                               context:nil
@@ -188,7 +202,7 @@
 
 - (void)testTrackWithQuantityRevenueAndProperties
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"foo"
                                                            properties:@{@"productId" : @"bar",
                                                                         @"quantity" : @10,
@@ -205,7 +219,7 @@
 
 - (void)testTrackWithPropertyViewedCategory
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_VIEWED_PRODUCT_CATEGORY
                                                            properties:@{ KAHUNA_CATEGORY : @"shirts" }
                                                               context:nil
@@ -218,7 +232,7 @@
 
 - (void)testTrackWithPropertyViewedProduct
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_VIEWED_PRODUCT
                                                            properties:@{ KAHUNA_NAME : @"gopher shirts" }
                                                               context:nil
@@ -234,7 +248,7 @@
 
 - (void)testTrackWithPropertyAddedProduct
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_ADDED_PRODUCT
                                                            properties:@{ KAHUNA_NAME : @"gopher shirts" }
                                                               context:nil
@@ -248,7 +262,7 @@
 
 - (void)testTrackWithPropertyCompletedOrder
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:KAHUNA_COMPLETED_ORDER
                                                            properties:@{ KAHUNA_DISCOUNT : @15.0 }
                                                               context:nil
@@ -271,7 +285,7 @@
 
 - (void)testScreenWithNoTrackAllPagesSettings
 {
-    [_integration initWithSettings:@{ @"apiKey" : @"foo" }];
+    INIT_WITH_SETTINGS;
     SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"foo" properties:@{} context:nil integrations:nil];
     
     [_integration screen:payload];

--- a/Pod/Classes/SEGKahunaDefines.h
+++ b/Pod/Classes/SEGKahunaDefines.h
@@ -1,6 +1,8 @@
-
-// SEGKahunaDefines.h
-// Copyright (c) 2014 Segment.io. All rights reserved.
+//
+//  SEGKahunaDefines.h
+//
+//  Copyright (c) 2012-2016 Kahuna. All rights reserved.
+//
 
 #ifndef Analytics_SEGKahunaDefines_h
 #define Analytics_SEGKahunaDefines_h

--- a/Pod/Classes/SEGKahunaIntegration.h
+++ b/Pod/Classes/SEGKahunaIntegration.h
@@ -2,10 +2,13 @@
 #import <Analytics/SEGIntegration.h>
 
 
-@interface SEGKahunaIntegration : NSObject <SEGIntegration>
+@interface SEGKahunaIntegration : NSObject <SEGIntegration> {
+    bool _applicationDidBecomeActiveAtleastOnce;
+}
 
 @property (nonatomic, strong) NSDictionary *settings;
 @property (nonatomic, strong) NSSet *kahunaCredentialsKeys;
+@property Class kahunaClass;
 
 - (id)initWithSettings:(NSDictionary *)settings;
 

--- a/Pod/Classes/SEGKahunaIntegration.h
+++ b/Pod/Classes/SEGKahunaIntegration.h
@@ -1,3 +1,9 @@
+//
+//  SEGKahunaIntegration.h
+//
+//  Copyright (c) 2012-2016 Kahuna. All rights reserved.
+//
+
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegration.h>
 

--- a/Pod/Classes/SEGKahunaIntegration.m
+++ b/Pod/Classes/SEGKahunaIntegration.m
@@ -1,3 +1,9 @@
+//
+//  SEGKahunaIntegration.m
+//
+//  Copyright (c) 2012-2016 Kahuna. All rights reserved.
+//
+
 #import "SEGKahunaIntegration.h"
 #import <Kahuna/Kahuna.h>
 #import <Analytics/SEGAnalyticsUtils.h>

--- a/Pod/Classes/SEGKahunaIntegration.m
+++ b/Pod/Classes/SEGKahunaIntegration.m
@@ -250,17 +250,7 @@
 
 - (void)receivedRemoteNotification:(NSDictionary *)userInfo
 {
-    // This method can be called in a background thread or the main thread. If the app is launched due to a push, then this method call
-    // comes in the background thread. But if the app is in background and the user clicks on the push, then this method
-    // is called on the main thread.
-    
-    if (_applicationDidBecomeActiveAtleastOnce) {
-        [self.kahunaClass handleNotification:userInfo withApplicationState:[UIApplication sharedApplication].applicationState];
-    } else {
-        // If the application never became active and we get a remote notification, then we will handle the notification assuming application
-        // is Inactive.
-        [self.kahunaClass handleNotification:userInfo withApplicationState:UIApplicationStateInactive];
-    }
+    [self handleActionWithIdentifier:nil forRemoteNotification:userInfo];
 }
 
 - (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error
@@ -275,7 +265,17 @@
 
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo
 {
-    [self.kahunaClass handleNotification:userInfo withApplicationState:[UIApplication sharedApplication].applicationState];
+    // This method can be called in a background thread or the main thread. If the app is launched due to a push, then this method call
+    // comes in the background thread. But if the app is in background and the user clicks on the push, then this method
+    // is called on the main thread.
+    
+    if (_applicationDidBecomeActiveAtleastOnce) {
+        [self.kahunaClass handleNotification:userInfo withActionIdentifier:identifier withApplicationState:[UIApplication sharedApplication].applicationState];
+    } else {
+        // If the application never became active and we get a remote notification, then we will handle the notification assuming application
+        // is Inactive.
+        [self.kahunaClass handleNotification:userInfo withActionIdentifier:identifier withApplicationState:UIApplicationStateInactive];
+    }
 }
 
 - (void)reset

--- a/Pod/Classes/SEGKahunaIntegrationFactory.h
+++ b/Pod/Classes/SEGKahunaIntegrationFactory.h
@@ -1,3 +1,9 @@
+//
+//  SEGKahunaIntegrationFactory.h
+//
+//  Copyright (c) 2012-2016 Kahuna. All rights reserved.
+//
+
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegrationFactory.h>
 

--- a/Pod/Classes/SEGKahunaIntegrationFactory.m
+++ b/Pod/Classes/SEGKahunaIntegrationFactory.m
@@ -1,3 +1,9 @@
+//
+//  SEGKahunaIntegrationFactory.m
+//
+//  Copyright (c) 2012-2016 Kahuna. All rights reserved.
+//
+
 #import "SEGKahunaIntegrationFactory.h"
 #import "SEGKahunaIntegration.h"
 


### PR DESCRIPTION
…Payload and then use that payload to call the internal methods. There is one internal method for each of Screen, Track and Identify.

Added a new property kahunaClass that will hold the Kahuna class reference. This enables us to use class Injection for Mockito testing.
Also modified the method "receivedRemoteNotification" to handle push notifications that result in app launches. When that happens the call to "receivedRemoteNotification" is Asynchronous. So the application state is already active by then. So we use a variable _applicationDidBecomeActiveAtleastOnce to detect if the app has become active or not.
Added OCMokito to the Podfile so that someone downloading the wrapper can run the OCMokito tests on their end by installing the necessary pods.