### PR TITLE
Adds subspec for static library workaround

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,13 +1,36 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-target 'Segment-Kahuna_Example', :exclusive => true do
-  pod "Segment-Kahuna", :path => "../"
+## Without use_frameworks!
+target 'Segment-Kahuna_Example' do
+     Use default subspec
+    pod "Segment-Kahuna", :path => "../"
+
 end
 
-target 'Segment-Kahuna_Tests', :exclusive => true do
+target 'Segment-Kahuna_Tests' do
   pod "Segment-Kahuna", :path => "../"
 
   pod 'Specta'
   pod 'Expecta'
   pod 'OCMockito'
 end
+
+
+## With use_frameworks!
+# Use only 'Segment-Kahuna/StaticLibWorkaround'
+
+#use_frameworks!
+#
+#target 'Segment-Kahuna_Example' do
+#    pod 'Segment-Kahuna/StaticLibWorkaround', :path => '../'
+#    pod 'Kahuna'
+#
+#end
+#
+#target 'Segment-Kahuna_Tests' do
+#    inherit! :search_paths
+#
+#    pod 'Specta'
+#    pod 'Expecta'
+#    pod 'OCMockito'
+#end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 ## Without use_frameworks!
 target 'Segment-Kahuna_Example' do
-     Use default subspec
+    # Use default subspec
     pod "Segment-Kahuna", :path => "../"
 
 end

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -155,7 +155,8 @@
                                                          integrations:nil];
     
     [_integration track:payload];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testTrackWithRevenueButNoQuantity
@@ -168,7 +169,8 @@
     
     [_integration track:payload];
     
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
     [verifyCount(_kahunaClassMock, never()) trackEvent:@"foo" withCount:anything() andValue:anything()];
 }
 
@@ -182,7 +184,8 @@
     
     [_integration track:payload];
     
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo"];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
     [verifyCount(_kahunaClassMock, never()) trackEvent:@"foo" withCount:anything() andValue:anything()];
 }
 
@@ -197,7 +200,8 @@
     [_integration track:payload];
     
     [verifyCount(_kahunaClassMock, never()) trackEvent:anything()];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo" withCount:4 andValue:1000];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo" withCount:4 andValue:1000];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testTrackWithQuantityRevenueAndProperties
@@ -214,7 +218,8 @@
     
     [_integration track:payload];
     
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo" withCount:10 andValue:500];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"foo" withCount:10 andValue:500];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testTrackWithPropertyViewedCategory
@@ -227,7 +232,8 @@
     [_integration track:payload];
     
     [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_VIEWED_CATEGORY : @"shirts", KAHUNA_CATEGORIES_VIEWED : @"shirts" }];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_VIEWED_PRODUCT_CATEGORY];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_VIEWED_PRODUCT_CATEGORY];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testTrackWithPropertyViewedProduct
@@ -242,7 +248,8 @@
     [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_PRODUCT_VIEWED_NAME : @"gopher shirts",
                                                                  KAHUNA_CATEGORIES_VIEWED : KAHUNA_NONE,
                                                                  KAHUNA_LAST_VIEWED_CATEGORY : KAHUNA_NONE }];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_VIEWED_PRODUCT];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_VIEWED_PRODUCT];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
     
 }
 
@@ -257,7 +264,8 @@
     
     [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_PRODUCT_ADDED_TO_CART_NAME : @"gopher shirts",
                                                                  KAHUNA_LAST_PRODUCT_ADDED_TO_CART_CATEGORY : KAHUNA_NONE }];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_ADDED_PRODUCT];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_ADDED_PRODUCT];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testTrackWithPropertyCompletedOrder
@@ -270,7 +278,8 @@
     [_integration track:payload];
     
     [verifyCount(_kahunaClassMock, times(1)) setUserAttributes:@{KAHUNA_LAST_PURCHASE_DISCOUNT : @15.0 }];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_COMPLETED_ORDER];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:KAHUNA_COMPLETED_ORDER];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testScreen
@@ -280,7 +289,8 @@
     SEGScreenPayload *payload = [[SEGScreenPayload alloc] initWithName:@"foo" properties:@{} context:nil integrations:nil];
     
     [_integration screen:payload];
-    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"Viewed foo Screen"];
+//    [verifyCount(_kahunaClassMock, times(1)) trackEvent:@"Viewed foo Screen"];
+    [verifyCount(_kahunaClassMock, times(1)) track:anything()];
 }
 
 - (void)testScreenWithNoTrackAllPagesSettings

--- a/Segment-Kahuna.podspec
+++ b/Segment-Kahuna.podspec
@@ -1,10 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = "Segment-Kahuna"
   s.version          = "1.0.0"
-  s.summary          = "Kahuna's segment wrapper for iOS library."
+  s.summary          = "Kahuna's wrapper for Segment's analytics-ios library."
 
   s.description      = <<-DESC
-                       Kahuna's wrapper integration for Segment's analytics-ios library.
+                       Analytics for iOS provides a single API that lets you
+                       integrate with over 100s of tools.
+
+                       This is Kahuna's integration wrapper for Segment's analytics-ios library.
                        DESC
 
   s.homepage         = "http://kahuna.com/"
@@ -24,8 +27,22 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
 
-  s.source_files = 'Pod/Classes/**/*'
 
-  s.dependency 'Analytics'
-  s.dependency 'Kahuna'
+  s.dependency 'Analytics', '~> 3.0'
+  s.default_subspec = 'Segment-Kahuna'
+
+  s.subspec 'Segment-Kahuna' do |default|
+    #This will get bundled unless a subspec is specified
+    default.dependency 'Kahuna'
+  end
+
+
+  s.subspec 'StaticLibWorkaround' do |workaround|
+    # For users who are unable to bundle static libraries as dependencies
+    # you can choose this subspec, but be sure to include the folling in your podfile
+    # pod 'Kahuna'
+    # Please manually add the following file preserved by Cocoapods to your xcodeproj file
+    workaround.preserve_paths = 'Pod/Classes/**/*'
+  end
+
 end


### PR DESCRIPTION
This workaround to Cocoapods [Static Library](https://github.com/CocoaPods/CocoaPods/issues/2926), or in this case, static framework issue.

The limitation occurs when an application is built in Swift, you are including `use_frameworks!` in your podfile, and are using a transitive dependency that is provided as a static library (or in Kahuna's case a static framework).

The current workaround (as outlined in this subspec) is to copy the integration code manually into your project, then depend on Kahuna directly. Instead of importing the integration from our library you would import the integration from your local copy. This eliminates the transitive dependency from the App -> Segment-Kahuna -> Kahuna to App -> Kahuna.

Tested with the following configurations

Without `use_frameworks!`
- Use default subspec

With `use_frameworks!`
- Use only Segment-Kahuna/StaticLibWorkaround

CC @mselevan 